### PR TITLE
fix(server): resolve single-entry ZIPs when the reported path has no inner file

### DIFF
--- a/MiSTer/Scripts/.config/mister_monitor/mister_status_server.py
+++ b/MiSTer/Scripts/.config/mister_monitor/mister_status_server.py
@@ -3206,7 +3206,23 @@ class MiSTerStatusHandler(BaseHTTPRequestHandler):
         try:
             with zipfile.ZipFile(zip_path, 'r') as zip_file:
                 zip_files = zip_file.namelist()
-                
+
+                # Strategy 0: internal_path is empty when the reported path IS
+                # the zip itself with nothing after it (is_zip_path() has no
+                # trailing "/innerfile" to split off) - some cores report just
+                # the zip path for a single-ROM archive rather than
+                # "zip/file.ext". Every strategy below is derived from
+                # internal_path, so they can never match when it's "": none of
+                # them compare against "the zip has exactly one entry" at all.
+                # That case has zero ambiguity, so resolve it directly instead
+                # of falling through to five guaranteed-empty comparisons.
+                if not internal_path and len(zip_files) == 1:
+                    only = zip_files[0]
+                    info = zip_file.getinfo(only)
+                    filename = os.path.basename(only)
+                    print(f"✅ File info (sole entry, no internal path given): {filename} ({info.file_size:,} bytes)")
+                    return filename, info.file_size, info.CRC
+
                 # Try multiple search strategies
                 search_paths = [
                     internal_path,


### PR DESCRIPTION
## Bug

Some cores report the loaded ROM path as just the zip file's own path,
with nothing after it, rather than `archive.zip/file.ext`. When that
happens, `is_zip_path()` computes the in-zip path as an empty string,
and every one of `get_zip_file_info_enhanced()`'s existing matching
strategies is derived from that empty string - so none of them can ever
match, even though the zip is valid and contains exactly one file.

Symptom: the ROM loads and displays correctly on-screen (core/game name
shown fine), but `/status/rom/details` reports
`"error": "File not found inside ZIP: "` and never produces a CRC/hash -
which looks exactly like a hash-matching problem downstream (RA/artwork
silently produce nothing) and isn't one.

## Fix

Adds a "Strategy 0" in `get_zip_file_info_enhanced()`: when no internal
path was given at all *and* the zip contains exactly one entry, that
entry is unambiguously the right one - use it directly rather than
falling through all five path-based matching strategies with nothing to
match against.

## Testing

Verified against a real zip on real hardware that was previously failing
with the empty-internal-path error - after this fix, CRC/hash resolve
correctly and RA/artwork work for that ROM. No behavior change for the
existing (non-empty internal path) cases; this only adds a fallback for
the specific single-entry/no-internal-path case that previously had none.